### PR TITLE
feat(blog): render articles from content/blog + CI deploy to Pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,66 @@
+---
+name: Deploy site to Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+# Allow the workflow to publish to GitHub Pages via OIDC.
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Only one concurrent Pages deploy; let an in-flight run finish.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build static site
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install Task
+        uses: arduino/setup-task@v2
+        with:
+          version: 3.x
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Render site (index.html + blog/<slug>/)
+        env:
+          CI: "true"
+          YOUTUBE_API_KEY: ${{ secrets.YOUTUBE_API_KEY }}
+        run: task render
+
+      - name: Stage publishable files
+        run: |
+          mkdir -p _site
+          cp -r index.html css js fonts uploads favicon.ico CNAME _site/
+          [ -d blog ] && cp -r blog _site/ || true
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: _site
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,8 @@
 
 # Ignore generated/temp files
 index.html
+/blog/
+_site/
 .youtube_cache.json
 test_render.py
 cv/build/

--- a/README.md
+++ b/README.md
@@ -30,6 +30,37 @@ Notes:
 - Rendering will minify HTML automatically when `CI` is set in the environment.
 - Dependencies are declared in `pyproject.toml`; Task will run `uv sync` automatically.
 
+## Blog
+
+Articles live as Markdown in `content/blog/<slug>.md` with a YAML front-matter block:
+
+```markdown
+---
+title: "Kubernetes probes are a mental model, not a checklist"
+date: 2026-06-21
+slug: kubernetes-probes-mental-model   # optional; defaults to the filename
+excerpt: "A one-line summary used in the blog list and meta description."
+tags: [Kubernetes, DevOps, SRE]
+# draft: true                          # optional; omit to publish
+---
+
+# Title repeated as H1 (stripped from the body — rendered from front-matter)
+
+Article body in Markdown (fenced code blocks and tables supported)…
+```
+
+`generate.py` scans `content/blog/`, renders each post to `blog/<slug>/index.html` (template:
+`post.html.j2`), and lists them in the site's `#blog` section. URLs are clean and readable:
+`https://alex-dovnar.in/blog/<slug>/`.
+
+**Publishing flow:** add the Markdown file (typically via the `/content-publish-blog` command in the
+content pipeline, which opens a PR), get the PR reviewed/merged to `main`. The
+`Deploy site to Pages` GitHub Action builds the site (`task render`) and deploys it — the post is
+live at its canonical URL on merge. Nothing is committed pre-built; HTML is a build artifact.
+
+> One-time setup for CI deploys: in repo **Settings → Pages**, set the source to **GitHub Actions**,
+> and add a `YOUTUBE_API_KEY` repository secret (`generate.py` requires it).
+
 ## CV / résumé
 
 The two résumé PDFs in `uploads/` are **generated**, not hand-edited. Sources live in `cv/`:

--- a/css/input.css
+++ b/css/input.css
@@ -1,9 +1,11 @@
 @import "tailwindcss";
 
-/* Scan the Jinja template (the file with literal class names), not the
+/* Scan the Jinja templates (the files with literal class names), not the
    generated output — keeps the build order-independent. */
 @source "../index.html.j2";
+@source "../post.html.j2";
 @source not "../index.html";
+@source not "../blog";
 
 /* ── Cloud-native dashboard design tokens ───────────────────────────── */
 @theme {
@@ -373,6 +375,154 @@
   figure.item i {
     @apply mt-2 block;
     color: var(--color-k8s);
+  }
+
+  /* Blog — post list (index #blog section) */
+  .post-list {
+    @apply m-0 flex list-none flex-col gap-4 p-0;
+  }
+  .post-item {
+    @apply border-b pb-4;
+    border-color: var(--color-border);
+  }
+  .post-item:last-child {
+    @apply border-b-0 pb-0;
+  }
+  .post-link {
+    @apply flex flex-wrap items-baseline gap-x-3 gap-y-1 no-underline;
+  }
+  .post-title {
+    @apply font-mono text-base font-semibold transition-colors;
+    color: var(--color-k8s);
+  }
+  .post-link:hover .post-title {
+    color: var(--color-cyan);
+  }
+  .post-date {
+    @apply font-mono text-xs;
+    color: var(--color-dim);
+  }
+  .post-excerpt {
+    @apply mt-1 text-sm leading-relaxed;
+    color: var(--color-muted);
+  }
+  .post-tags {
+    @apply mt-1.5 flex flex-wrap gap-2;
+  }
+  .post-tag {
+    @apply font-mono text-xs;
+    color: var(--color-cyan);
+  }
+
+  /* Blog — single post page */
+  .post-article {
+    @apply mx-auto w-full min-w-0 max-w-[760px] px-4 py-6 sm:px-6;
+  }
+  .post-header {
+    @apply mb-6;
+  }
+  .post-h1 {
+    @apply font-mono text-2xl font-bold leading-tight sm:text-3xl;
+    color: var(--color-fg);
+  }
+  .post-meta {
+    @apply mt-2 flex flex-wrap items-center gap-x-3 gap-y-1 font-mono text-xs;
+    color: var(--color-dim);
+  }
+  .post-back {
+    @apply inline-flex items-center gap-1.5 font-mono text-sm no-underline transition-colors;
+    color: var(--color-muted);
+  }
+  .post-back:hover {
+    color: var(--color-k8s);
+  }
+
+  /* Prose styling for the article body */
+  .post-body {
+    @apply leading-relaxed;
+    color: var(--color-fg);
+  }
+  .post-body h2 {
+    @apply mt-8 mb-3 font-mono text-xl font-semibold;
+    color: var(--color-k8s);
+  }
+  .post-body h3 {
+    @apply mt-6 mb-2 text-lg font-semibold;
+    color: var(--color-warn);
+  }
+  .post-body p {
+    @apply my-4;
+  }
+  .post-body ul,
+  .post-body ol {
+    @apply my-4 flex flex-col gap-2 pl-6;
+  }
+  .post-body ul {
+    @apply list-disc;
+  }
+  .post-body ol {
+    @apply list-decimal;
+  }
+  .post-body li {
+    @apply pl-1;
+  }
+  .post-body li::marker {
+    color: var(--color-k8s);
+  }
+  .post-body strong {
+    @apply font-semibold;
+    color: var(--color-fg);
+  }
+  .post-body em {
+    color: var(--color-warn);
+  }
+  .post-body a {
+    color: var(--color-k8s);
+    border-bottom: 1px dotted currentColor;
+    @apply transition-colors;
+  }
+  .post-body a:hover {
+    color: var(--color-cyan);
+  }
+  .post-body code {
+    @apply rounded px-1.5 py-0.5 font-mono text-[0.85em];
+    background: var(--color-elev);
+    color: var(--color-cyan);
+  }
+  .post-body pre {
+    @apply my-5 overflow-x-auto rounded-lg p-4 text-sm leading-relaxed;
+    background: var(--color-head);
+    border: 1px solid var(--color-border);
+  }
+  .post-body pre code {
+    @apply p-0;
+    background: transparent;
+    color: var(--color-fg);
+  }
+  .post-body blockquote {
+    @apply my-5 border-l-2 pl-4 italic;
+    border-color: var(--color-k8s);
+    color: var(--color-muted);
+  }
+  .post-body table {
+    @apply my-5 w-full border-collapse font-mono text-sm;
+  }
+  .post-body th,
+  .post-body td {
+    @apply px-3 py-2 text-left;
+    border: 1px solid var(--color-border);
+  }
+  .post-body th {
+    background: var(--color-head);
+    color: var(--color-fg);
+  }
+  .post-body img {
+    @apply my-5 mx-auto block max-w-full rounded-lg;
+    border: 1px solid var(--color-border);
+  }
+  .post-body h2 a,
+  .post-body h3 a {
+    border-bottom: none;
   }
 
   /* Contact / footer */

--- a/css/tailwind.css
+++ b/css/tailwind.css
@@ -18,6 +18,10 @@
     --text-lg--line-height: calc(1.75 / 1.125);
     --text-xl: 1.25rem;
     --text-xl--line-height: calc(1.75 / 1.25);
+    --text-2xl: 1.5rem;
+    --text-2xl--line-height: calc(2 / 1.5);
+    --text-3xl: 1.875rem;
+    --text-3xl--line-height: calc(2.25 / 1.875);
     --text-4xl: 2.25rem;
     --text-4xl--line-height: calc(2.5 / 2.25);
     --text-5xl: 3rem;
@@ -265,8 +269,14 @@
   .mt-4 {
     margin-top: calc(var(--spacing) * 4);
   }
+  .mt-5 {
+    margin-top: calc(var(--spacing) * 5);
+  }
   .mt-6 {
     margin-top: calc(var(--spacing) * 6);
+  }
+  .mt-10 {
+    margin-top: calc(var(--spacing) * 10);
   }
   .mr-4 {
     margin-right: calc(var(--spacing) * 4);
@@ -276,6 +286,9 @@
   }
   .block {
     display: block;
+  }
+  .contents {
+    display: contents;
   }
   .flex {
     display: flex;
@@ -341,9 +354,17 @@
   .overflow-y-auto {
     overflow-y: auto;
   }
+  .rounded-t-xl {
+    border-top-left-radius: var(--radius-xl);
+    border-top-right-radius: var(--radius-xl);
+  }
   .border {
     border-style: var(--tw-border-style);
     border-width: 1px;
+  }
+  .border-t {
+    border-top-style: var(--tw-border-style);
+    border-top-width: 1px;
   }
   .border-r {
     border-right-style: var(--tw-border-style);
@@ -375,6 +396,9 @@
   }
   .py-6 {
     padding-block: calc(var(--spacing) * 6);
+  }
+  .pt-6 {
+    padding-top: calc(var(--spacing) * 6);
   }
   .pt-12 {
     padding-top: calc(var(--spacing) * 12);
@@ -408,6 +432,9 @@
   }
   .text-k8s {
     color: var(--color-k8s);
+  }
+  .text-muted {
+    color: var(--color-muted);
   }
   .italic {
     font-style: italic;
@@ -1098,6 +1125,257 @@
     margin-top: calc(var(--spacing) * 2);
     display: block;
     color: var(--color-k8s);
+  }
+  .post-list {
+    margin: calc(var(--spacing) * 0);
+    display: flex;
+    list-style-type: none;
+    flex-direction: column;
+    gap: calc(var(--spacing) * 4);
+    padding: calc(var(--spacing) * 0);
+  }
+  .post-item {
+    border-bottom-style: var(--tw-border-style);
+    border-bottom-width: 1px;
+    padding-bottom: calc(var(--spacing) * 4);
+    border-color: var(--color-border);
+  }
+  .post-item:last-child {
+    border-bottom-style: var(--tw-border-style);
+    border-bottom-width: 0px;
+    padding-bottom: calc(var(--spacing) * 0);
+  }
+  .post-link {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: baseline;
+    column-gap: calc(var(--spacing) * 3);
+    row-gap: calc(var(--spacing) * 1);
+    text-decoration-line: none;
+  }
+  .post-title {
+    font-family: var(--font-mono);
+    font-size: var(--text-base);
+    line-height: var(--tw-leading, var(--text-base--line-height));
+    --tw-font-weight: var(--font-weight-semibold);
+    font-weight: var(--font-weight-semibold);
+    transition-property: color, background-color, border-color, outline-color, text-decoration-color, fill, stroke, --tw-gradient-from, --tw-gradient-via, --tw-gradient-to;
+    transition-timing-function: var(--tw-ease, var(--default-transition-timing-function));
+    transition-duration: var(--tw-duration, var(--default-transition-duration));
+    color: var(--color-k8s);
+  }
+  .post-link:hover .post-title {
+    color: var(--color-cyan);
+  }
+  .post-date {
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    line-height: var(--tw-leading, var(--text-xs--line-height));
+    color: var(--color-dim);
+  }
+  .post-excerpt {
+    margin-top: calc(var(--spacing) * 1);
+    font-size: var(--text-sm);
+    line-height: var(--tw-leading, var(--text-sm--line-height));
+    --tw-leading: var(--leading-relaxed);
+    line-height: var(--leading-relaxed);
+    color: var(--color-muted);
+  }
+  .post-tags {
+    margin-top: calc(var(--spacing) * 1.5);
+    display: flex;
+    flex-wrap: wrap;
+    gap: calc(var(--spacing) * 2);
+  }
+  .post-tag {
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    line-height: var(--tw-leading, var(--text-xs--line-height));
+    color: var(--color-cyan);
+  }
+  .post-article {
+    margin-inline: auto;
+    width: 100%;
+    max-width: 760px;
+    min-width: calc(var(--spacing) * 0);
+    padding-inline: calc(var(--spacing) * 4);
+    padding-block: calc(var(--spacing) * 6);
+    @media (width >= 40rem) {
+      padding-inline: calc(var(--spacing) * 6);
+    }
+  }
+  .post-header {
+    margin-bottom: calc(var(--spacing) * 6);
+  }
+  .post-h1 {
+    font-family: var(--font-mono);
+    font-size: var(--text-2xl);
+    line-height: var(--tw-leading, var(--text-2xl--line-height));
+    --tw-leading: var(--leading-tight);
+    line-height: var(--leading-tight);
+    --tw-font-weight: var(--font-weight-bold);
+    font-weight: var(--font-weight-bold);
+    @media (width >= 40rem) {
+      font-size: var(--text-3xl);
+      line-height: var(--tw-leading, var(--text-3xl--line-height));
+    }
+    color: var(--color-fg);
+  }
+  .post-meta {
+    margin-top: calc(var(--spacing) * 2);
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    column-gap: calc(var(--spacing) * 3);
+    row-gap: calc(var(--spacing) * 1);
+    font-family: var(--font-mono);
+    font-size: var(--text-xs);
+    line-height: var(--tw-leading, var(--text-xs--line-height));
+    color: var(--color-dim);
+  }
+  .post-back {
+    display: inline-flex;
+    align-items: center;
+    gap: calc(var(--spacing) * 1.5);
+    font-family: var(--font-mono);
+    font-size: var(--text-sm);
+    line-height: var(--tw-leading, var(--text-sm--line-height));
+    text-decoration-line: none;
+    transition-property: color, background-color, border-color, outline-color, text-decoration-color, fill, stroke, --tw-gradient-from, --tw-gradient-via, --tw-gradient-to;
+    transition-timing-function: var(--tw-ease, var(--default-transition-timing-function));
+    transition-duration: var(--tw-duration, var(--default-transition-duration));
+    color: var(--color-muted);
+  }
+  .post-back:hover {
+    color: var(--color-k8s);
+  }
+  .post-body {
+    --tw-leading: var(--leading-relaxed);
+    line-height: var(--leading-relaxed);
+    color: var(--color-fg);
+  }
+  .post-body h2 {
+    margin-top: calc(var(--spacing) * 8);
+    margin-bottom: calc(var(--spacing) * 3);
+    font-family: var(--font-mono);
+    font-size: var(--text-xl);
+    line-height: var(--tw-leading, var(--text-xl--line-height));
+    --tw-font-weight: var(--font-weight-semibold);
+    font-weight: var(--font-weight-semibold);
+    color: var(--color-k8s);
+  }
+  .post-body h3 {
+    margin-top: calc(var(--spacing) * 6);
+    margin-bottom: calc(var(--spacing) * 2);
+    font-size: var(--text-lg);
+    line-height: var(--tw-leading, var(--text-lg--line-height));
+    --tw-font-weight: var(--font-weight-semibold);
+    font-weight: var(--font-weight-semibold);
+    color: var(--color-warn);
+  }
+  .post-body p {
+    margin-block: calc(var(--spacing) * 4);
+  }
+  .post-body ul, .post-body ol {
+    margin-block: calc(var(--spacing) * 4);
+    display: flex;
+    flex-direction: column;
+    gap: calc(var(--spacing) * 2);
+    padding-left: calc(var(--spacing) * 6);
+  }
+  .post-body ul {
+    list-style-type: disc;
+  }
+  .post-body ol {
+    list-style-type: decimal;
+  }
+  .post-body li {
+    padding-left: calc(var(--spacing) * 1);
+  }
+  .post-body li::marker {
+    color: var(--color-k8s);
+  }
+  .post-body strong {
+    --tw-font-weight: var(--font-weight-semibold);
+    font-weight: var(--font-weight-semibold);
+    color: var(--color-fg);
+  }
+  .post-body em {
+    color: var(--color-warn);
+  }
+  .post-body a {
+    color: var(--color-k8s);
+    border-bottom: 1px dotted currentColor;
+    transition-property: color, background-color, border-color, outline-color, text-decoration-color, fill, stroke, --tw-gradient-from, --tw-gradient-via, --tw-gradient-to;
+    transition-timing-function: var(--tw-ease, var(--default-transition-timing-function));
+    transition-duration: var(--tw-duration, var(--default-transition-duration));
+  }
+  .post-body a:hover {
+    color: var(--color-cyan);
+  }
+  .post-body code {
+    border-radius: 0.25rem;
+    padding-inline: calc(var(--spacing) * 1.5);
+    padding-block: calc(var(--spacing) * 0.5);
+    font-family: var(--font-mono);
+    font-size: 0.85em;
+    background: var(--color-elev);
+    color: var(--color-cyan);
+  }
+  .post-body pre {
+    margin-block: calc(var(--spacing) * 5);
+    overflow-x: auto;
+    border-radius: var(--radius-lg);
+    padding: calc(var(--spacing) * 4);
+    font-size: var(--text-sm);
+    line-height: var(--tw-leading, var(--text-sm--line-height));
+    --tw-leading: var(--leading-relaxed);
+    line-height: var(--leading-relaxed);
+    background: var(--color-head);
+    border: 1px solid var(--color-border);
+  }
+  .post-body pre code {
+    padding: calc(var(--spacing) * 0);
+    background: transparent;
+    color: var(--color-fg);
+  }
+  .post-body blockquote {
+    margin-block: calc(var(--spacing) * 5);
+    border-left-style: var(--tw-border-style);
+    border-left-width: 2px;
+    padding-left: calc(var(--spacing) * 4);
+    font-style: italic;
+    border-color: var(--color-k8s);
+    color: var(--color-muted);
+  }
+  .post-body table {
+    margin-block: calc(var(--spacing) * 5);
+    width: 100%;
+    border-collapse: collapse;
+    font-family: var(--font-mono);
+    font-size: var(--text-sm);
+    line-height: var(--tw-leading, var(--text-sm--line-height));
+  }
+  .post-body th, .post-body td {
+    padding-inline: calc(var(--spacing) * 3);
+    padding-block: calc(var(--spacing) * 2);
+    text-align: left;
+    border: 1px solid var(--color-border);
+  }
+  .post-body th {
+    background: var(--color-head);
+    color: var(--color-fg);
+  }
+  .post-body img {
+    margin-inline: auto;
+    margin-block: calc(var(--spacing) * 5);
+    display: block;
+    max-width: 100%;
+    border-radius: var(--radius-lg);
+    border: 1px solid var(--color-border);
+  }
+  .post-body h2 a, .post-body h3 a {
+    border-bottom: none;
   }
   .contact-info {
     display: flex;

--- a/generate.py
+++ b/generate.py
@@ -1,14 +1,18 @@
 #!env python3
+import datetime
 import json
 import logging
 import os
 import re
 from pathlib import Path
 
-import minify_html
+import frontmatter
 from jinja2 import Template
 from markdown import markdown
 from pyyoutube import Api
+
+# Public base URL of the site — used to build absolute canonical links for posts.
+BASE_URL = "https://alex-dovnar.in"
 
 # Configure logging
 LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO").upper()
@@ -47,6 +51,69 @@ def load_markdown(path: str) -> str:
             return strip_top_h1(rendered)
     logger.warning("Markdown file not found: %s", path)
     return ""
+
+
+def _coerce_date(value) -> str:
+    """Normalize a frontmatter date (date/datetime/str) to an ISO YYYY-MM-DD string."""
+    if isinstance(value, (datetime.date, datetime.datetime)):
+        return value.strftime("%Y-%m-%d")
+    return str(value or "").strip()
+
+
+def _human_date(iso: str) -> str:
+    """Render an ISO date as e.g. 'Jun 21, 2026'; fall back to the raw string."""
+    try:
+        return datetime.datetime.strptime(iso, "%Y-%m-%d").strftime("%b %-d, %Y")
+    except ValueError:
+        return iso
+
+
+def load_blog_posts(content_dir: str) -> list:
+    """Load blog articles from content/blog/*.md.
+
+    Each file carries YAML frontmatter (title, date, slug, excerpt, tags, draft).
+    Returns a list of post dicts (newest first), skipping anything marked draft.
+    """
+    blog_dir = Path(content_dir) / "blog"
+    if not blog_dir.is_dir():
+        logger.info("No blog directory at %s — skipping posts", blog_dir)
+        return []
+
+    posts = []
+    for md_path in sorted(blog_dir.glob("*.md")):
+        logger.debug("Loading blog post %s", md_path)
+        post = frontmatter.load(md_path)
+        meta = post.metadata
+        if meta.get("draft"):
+            logger.info("Skipping draft post %s", md_path)
+            continue
+
+        slug = str(meta.get("slug") or md_path.stem).strip()
+        iso_date = _coerce_date(meta.get("date"))
+        body_html = strip_top_h1(
+            markdown(post.content, extensions=["fenced_code", "tables", "toc", "sane_lists"])
+        )
+        tags = meta.get("tags") or []
+        if isinstance(tags, str):
+            tags = [t.strip() for t in tags.replace(",", " ").split() if t.strip()]
+
+        posts.append(
+            {
+                "slug": slug,
+                "title": str(meta.get("title") or slug).strip(),
+                "date": iso_date,
+                "date_human": _human_date(iso_date),
+                "excerpt": str(meta.get("excerpt") or "").strip(),
+                "tags": tags,
+                "body_html": body_html,
+                "url": f"/blog/{slug}/",
+                "canonical": f"{BASE_URL}/blog/{slug}/",
+            }
+        )
+
+    posts.sort(key=lambda p: p["date"], reverse=True)
+    logger.info("Loaded %d blog post(s)", len(posts))
+    return posts
 
 
 def load_youtube_cache(cache_file: str = ".youtube_cache.json") -> dict:
@@ -92,47 +159,56 @@ education_html = load_markdown(os.path.join(content_dir, "education.md"))
 skills_html = load_markdown(os.path.join(content_dir, "skills.md"))
 highlights_html = load_markdown(os.path.join(content_dir, "highlights.md"))
 
-logger.debug("Initializing YouTube API client")
-api = Api(api_key=os.environ["YOUTUBE_API_KEY"])
+# Load blog posts (content/blog/*.md)
+posts = load_blog_posts(content_dir)
 
-# Load cache
+# Load cache first — it lets the site build (videos + blog) even if the API key
+# is absent (local preview) or the API call fails.
 youtube_cache = load_youtube_cache()
 logger.info(f"Loaded {len(youtube_cache)} videos from cache")
 
-logger.debug("Fetching playlist items (IDs only)")
-playlist_item_by_playlist = api.get_playlist_items(
-    playlist_id="PLAGNQxMisRs1F-1CryCRWKjmEsj5GAy6y", count=100
-)
-logger.debug("Fetched %d playlist items", len(playlist_item_by_playlist.items))
+youtube_api_key = os.environ.get("YOUTUBE_API_KEY")
+if youtube_api_key:
+    logger.debug("Initializing YouTube API client")
+    api = Api(api_key=youtube_api_key)
 
-# Extract video IDs from playlist
-playlist_video_ids = [
-    item.contentDetails.videoId for item in playlist_item_by_playlist.items
-]
-logger.info(f"Found {len(playlist_video_ids)} videos in playlist")
+    logger.debug("Fetching playlist items (IDs only)")
+    playlist_item_by_playlist = api.get_playlist_items(
+        playlist_id="PLAGNQxMisRs1F-1CryCRWKjmEsj5GAy6y", count=100
+    )
+    logger.debug("Fetched %d playlist items", len(playlist_item_by_playlist.items))
 
-# Find new videos (not in cache)
-new_video_ids = [vid for vid in playlist_video_ids if vid not in youtube_cache]
-logger.info(f"Found {len(new_video_ids)} new videos to fetch")
+    # Extract video IDs from playlist
+    playlist_video_ids = [
+        item.contentDetails.videoId for item in playlist_item_by_playlist.items
+    ]
+    logger.info(f"Found {len(playlist_video_ids)} videos in playlist")
 
-# Fetch details only for new videos
-youtube_raw = dict(youtube_cache)  # Start with cached data
-for video_id in new_video_ids:
-    logger.info(f"Fetching new video: {video_id}")
-    try:
-        video_data = fetch_video_details(api, video_id)
-        youtube_raw[video_id] = video_data
-    except Exception as e:
-        logger.error(f"Failed to fetch video {video_id}: {e}")
+    # Find new videos (not in cache)
+    new_video_ids = [vid for vid in playlist_video_ids if vid not in youtube_cache]
+    logger.info(f"Found {len(new_video_ids)} new videos to fetch")
 
-# Remove videos that are no longer in the playlist
-youtube_raw = {
-    vid: data for vid, data in youtube_raw.items() if vid in playlist_video_ids
-}
-logger.info(f"Total videos after cleanup: {len(youtube_raw)}")
+    # Fetch details only for new videos
+    youtube_raw = dict(youtube_cache)  # Start with cached data
+    for video_id in new_video_ids:
+        logger.info(f"Fetching new video: {video_id}")
+        try:
+            video_data = fetch_video_details(api, video_id)
+            youtube_raw[video_id] = video_data
+        except Exception as e:
+            logger.error(f"Failed to fetch video {video_id}: {e}")
 
-# Save updated cache
-save_youtube_cache(youtube_raw)
+    # Remove videos that are no longer in the playlist
+    youtube_raw = {
+        vid: data for vid, data in youtube_raw.items() if vid in playlist_video_ids
+    }
+    logger.info(f"Total videos after cleanup: {len(youtube_raw)}")
+
+    # Save updated cache
+    save_youtube_cache(youtube_raw)
+else:
+    logger.warning("YOUTUBE_API_KEY not set — building from cache only (videos may be empty)")
+    youtube_raw = dict(youtube_cache)
 
 logger.debug("Sorting %d videos by publishedAt desc", len(youtube_raw))
 youtube = sorted(youtube_raw.items(), key=lambda x: x[1]["publishedAt"], reverse=True)
@@ -162,13 +238,34 @@ html = template.render(
     education_html=education_html,
     skills_html=skills_html,
     highlights_html=highlights_html,
+    posts=posts,
 )
 
+ci = bool(os.getenv("CI", False))
+
+
+def write_html(out_path: Path, rendered: str):
+    if ci:
+        # Imported lazily: minify_html is only needed for CI builds, and avoiding
+        # the hard import lets the site render locally without a Rust toolchain.
+        import minify_html
+
+        rendered = minify_html.minify(rendered)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(rendered, encoding="utf-8")
+
+
 logger.debug("Writing output to index.html")
-htmlFile = open("./index.html", mode="w+")
-if os.getenv("CI", False):
-    logger.debug("CI detected: minifying HTML output")
-    html = minify_html.minify(html)
-htmlFile.write(html)
-htmlFile.close()
+write_html(Path("index.html"), html)
 logger.info("Generation complete: index.html updated")
+
+# Render individual blog post pages to blog/<slug>/index.html
+if posts:
+    logger.debug("Reading Jinja template from post.html.j2")
+    with open("./post.html.j2", mode="r") as f:
+        post_template = Template(f.read())
+    for post in posts:
+        logger.info("Rendering blog post: %s", post["slug"])
+        post_html = post_template.render(post=post, posts=posts)
+        write_html(Path("blog") / post["slug"] / "index.html", post_html)
+    logger.info("Rendered %d blog post page(s)", len(posts))

--- a/index.html.j2
+++ b/index.html.j2
@@ -50,7 +50,7 @@
         <a href="#experience" class="nav-item"><i class="fas fa-briefcase"></i>experience<span class="nav-count">4</span></a>
         <a href="#skills" class="nav-item"><i class="fas fa-layer-group"></i>skills</a>
         <a href="#education" class="nav-item"><i class="fas fa-graduation-cap"></i>education</a>
-        <a href="#blog" class="nav-item"><i class="fas fa-rss"></i>blog<span class="nav-count">0</span></a>
+        <a href="#blog" class="nav-item"><i class="fas fa-rss"></i>blog<span class="nav-count">{{ posts|length if posts else 0 }}</span></a>
         <a href="#videos" class="nav-item"><i class="fas fa-video"></i>talks<span class="nav-count">70+</span></a>
         <a href="#contact" class="nav-item"><i class="fas fa-envelope"></i>contact</a>
       </nav>
@@ -131,8 +131,23 @@
           <span class="prompt-cursor">$</span><span class="prompt-cmd">kubectl get</span><span class="prompt-res">posts</span><span class="prompt-flag">-A</span>
         </div>
         <div class="panel-body">
+          {% if posts %}
+          <ul class="post-list">
+            {% for post in posts %}
+            <li class="post-item">
+              <a href="{{ post.url }}" class="post-link">
+                <span class="post-title">{{ post.title }}</span>
+                {% if post.date_human %}<span class="post-date">{{ post.date_human }}</span>{% endif %}
+              </a>
+              {% if post.excerpt %}<p class="post-excerpt">{{ post.excerpt }}</p>{% endif %}
+              {% if post.tags %}<p class="post-tags">{% for tag in post.tags %}<span class="post-tag">#{{ tag }}</span> {% endfor %}</p>{% endif %}
+            </li>
+            {% endfor %}
+          </ul>
+          {% else %}
           <p class="empty-state">No resources found in default namespace.</p>
           <p class="mt-2 text-sm text-dim">Articles on DevOps, Cloud Architecture &amp; best practices — coming soon.</p>
+          {% endif %}
         </div>
       </section>
 

--- a/post.html.j2
+++ b/post.html.j2
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <title>{{ post.title }} — Alex Dovnar</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="description" content="{{ post.excerpt }}" />
+    {% if post.tags %}<meta name="keywords" content="{{ post.tags | join(', ') }}" />{% endif %}
+    <link rel="canonical" href="{{ post.canonical }}" />
+    <link rel="shortcut icon" href="../../favicon.ico">
+
+    <!-- Open Graph -->
+    <meta property="og:type" content="article" />
+    <meta property="og:title" content="{{ post.title }}" />
+    <meta property="og:description" content="{{ post.excerpt }}" />
+    <meta property="og:url" content="{{ post.canonical }}" />
+    <meta name="twitter:card" content="summary" />
+
+    <!-- Fonts -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@400;500;600;700&family=Inter:wght@300;400;500;600;700&display=swap">
+
+    <!-- Styles -->
+    <link rel="stylesheet" href="../../css/tailwind.css" type="text/css">
+    <link rel="stylesheet" href="../../fonts/fontawesome-free/css/all.min.css" type="text/css">
+  </head>
+
+  <body class="min-h-dvh bg-bg font-sans text-fg">
+
+    <!-- Context Bar -->
+    <header class="ctx-bar">
+      <a href="../../" class="hidden font-mono text-base font-semibold text-k8s sm:inline">&gt; alex-dovnar</a>
+      <span class="ctx-pill"><span class="status-dot status-ok"></span>ctx:&nbsp;<b>prod</b></span>
+      <span class="ctx-pill hidden sm:flex">ns:&nbsp;<b>blog</b></span>
+      <nav class="ml-auto flex gap-2">
+        <a href="../../#blog" class="cv-btn">All posts</a>
+      </nav>
+    </header>
+
+    <main class="pt-12">
+      <article class="post-article">
+
+        <a href="../../#blog" class="post-back"><i class="fas fa-arrow-left"></i>back to posts</a>
+
+        <header class="post-header">
+          <div class="panel-head mt-4 rounded-t-xl">
+            <span class="prompt-cursor">$</span><span class="prompt-cmd">kubectl describe</span><span class="prompt-res">post/{{ post.slug }}</span>
+          </div>
+          <div class="mt-5">
+            <h1 class="post-h1">{{ post.title }}</h1>
+            <div class="post-meta">
+              {% if post.date_human %}<span><i class="fas fa-calendar-day"></i>&nbsp;{{ post.date_human }}</span>{% endif %}
+              <span>·&nbsp;Alex Dovnar</span>
+              {% if post.tags %}<span>·&nbsp;{% for tag in post.tags %}#{{ tag }} {% endfor %}</span>{% endif %}
+            </div>
+          </div>
+        </header>
+
+        <div class="post-body">
+          {{ post.body_html | safe }}
+        </div>
+
+        <footer class="mt-10 border-t border-border pt-6">
+          <p class="font-mono text-sm text-muted">
+            Written by Alex Dovnar — DevOps &amp; Cloud Architect.
+            Find me on <a href="https://www.linkedin.com/in/dovnaralex/" target="_blank" rel="noopener" class="text-k8s">LinkedIn</a>.
+          </p>
+          <a href="../../#blog" class="post-back mt-4"><i class="fas fa-arrow-left"></i>back to posts</a>
+        </footer>
+
+      </article>
+    </main>
+
+  </body>
+</html>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
   "minify-html>=0.15.0",
   "python-youtube>=0.9.4",
   "markdown>=3.6",
+  "python-frontmatter>=1.1.0",
 ]
 
 [tool.uv]

--- a/uv.lock
+++ b/uv.lock
@@ -208,6 +208,7 @@ dependencies = [
     { name = "jinja2" },
     { name = "markdown" },
     { name = "minify-html" },
+    { name = "python-frontmatter" },
     { name = "python-youtube" },
 ]
 
@@ -216,7 +217,20 @@ requires-dist = [
     { name = "jinja2", specifier = ">=3.1.2" },
     { name = "markdown", specifier = ">=3.6" },
     { name = "minify-html", specifier = ">=0.15.0" },
+    { name = "python-frontmatter", specifier = ">=1.1.0" },
     { name = "python-youtube", specifier = ">=0.9.4" },
+]
+
+[[package]]
+name = "python-frontmatter"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9d/e8/79cbe69864d44f3b48e70ebee0a872a7d5a4e7150c9f8577ed7a5beefff0/python_frontmatter-1.3.0.tar.gz", hash = "sha256:acc73e477a568dc2a25c9e130c6c68ae8daa8c204c8f7e813db47d6a7280dcf2", size = 8322, upload-time = "2026-05-20T19:21:44.164Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/a3/17c284b4f4d8ad50f0f9ba70ad8fcc35c777aeafcdbbffdd91bbdc5ab379/python_frontmatter-1.3.0-py3-none-any.whl", hash = "sha256:9f7dd9260bec99044219159a329f64f039087f9d1a2124c9442556f2fe6f82ec", size = 10562, upload-time = "2026-05-20T19:21:43.323Z" },
 ]
 
 [[package]]
@@ -232,6 +246,52 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c8/d4/856cd88fc64b40992cc5af4e247d347ee9605fdea3bf21f7c936e5411cb2/python_youtube-0.9.8.tar.gz", hash = "sha256:b6c679fbda07ecb114a95576c470a9f43f367ab71c61dc4b030dbfa2ea0826eb", size = 69499, upload-time = "2025-08-22T08:40:25.453Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/36/f6/fd915b163fa18f95e420025fcc29acf74769c2f72f855e119edaf4ff1589/python_youtube-0.9.8-py3-none-any.whl", hash = "sha256:de45a56cc588fb8c5b19a0d4d9425edef2959f59cf9793892da25b3d5afb270f", size = 82254, upload-time = "2025-08-22T08:40:24.052Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063, upload-time = "2025-09-25T21:32:11.445Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973, upload-time = "2025-09-25T21:32:12.492Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116, upload-time = "2025-09-25T21:32:13.652Z" },
+    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011, upload-time = "2025-09-25T21:32:15.21Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870, upload-time = "2025-09-25T21:32:16.431Z" },
+    { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089, upload-time = "2025-09-25T21:32:17.56Z" },
+    { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181, upload-time = "2025-09-25T21:32:18.834Z" },
+    { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658, upload-time = "2025-09-25T21:32:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003, upload-time = "2025-09-25T21:32:21.167Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344, upload-time = "2025-09-25T21:32:22.617Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Add a blog system to the static site:
- generate.py: load_blog_posts() scans content/blog/*.md (YAML frontmatter), renders each to blog/<slug>/index.html via new post.html.j2; lazy minify_html import and optional YOUTUBE_API_KEY so the site builds locally without them.
- index.html.j2: #blog section lists posts; nav count is live.
- css: post-list and article-prose styles (code, tables, blockquotes).
- .github/workflows/deploy.yml: build (task render) + deploy to Pages on merge.
- pyproject/uv.lock: add python-frontmatter.

Clean readable URLs: https://alex-dovnar.in/blog/<slug>/