### PR TITLE
blog: run the two published posts through the humanizer quality gate

### DIFF
--- a/content/blog/ai-code-security-trust-boundary.md
+++ b/content/blog/ai-code-security-trust-boundary.md
@@ -2,17 +2,17 @@
 title: "AI Code Security Is a Runtime Problem, Not a Review Problem"
 date: 2026-06-26
 slug: ai-code-security-trust-boundary
-excerpt: "30% of developers knowingly ship vulnerable AI code to production — the fix isn't better review, it's a three-layer trust boundary that treats runtime as the real safety line."
+excerpt: "30% of developers knowingly ship vulnerable AI code to production. The fix isn't better review, it's a three-layer trust boundary that treats runtime as the real safety line."
 tags: [DevOps, Security, AI, PlatformEngineering, AppSec]
 ---
 
 # AI Code Security Is a Runtime Problem, Not a Review Problem
 
-Thirty percent of developers knowingly ship vulnerable AI-generated code to production. That number comes from a Checkmarx survey of 2,350 developers, CISOs, and AppSec managers published in June 2026 — and the more alarming figure is buried just below it: 93% of those respondents have already experienced a security breach through vulnerable applications.
+Thirty percent of developers knowingly ship vulnerable AI-generated code to production. That number comes from a Checkmarx survey of 2,350 developers, CISOs, and AppSec managers published in June 2026, and the more alarming figure is buried just below it: 93% of those respondents have already experienced a security breach through vulnerable applications.
 
 We know. We ship anyway. "Risk is normalized," the report concludes.
 
-If you're building with AI coding tools — and at this point most teams are — this post is about how to actually close that gap. Not "don't use AI." Not "review harder." A trust boundary that treats AI-generated code for what it actually is.
+If you're building with AI coding tools, and at this point most teams are, this post is about how to actually close that gap. Not "don't use AI." Not "review harder." A trust boundary that treats AI-generated code for what it actually is.
 
 <details class="deck-details">
 <summary><span class="deck-chevron">▸</span>The 60-second version — flip through the deck<span class="deck-hint">8 slides · swipe →</span></summary>
@@ -42,15 +42,15 @@ The supply side comes from Apiiro's research across Fortune 50 enterprise reposi
 <div class="viz-card accent-err"><span class="vc-name">AI creates the timebombs</span><span class="vc-note">Privilege-escalation paths <em>up 322%</em> · architectural design flaws <em>up 153%</em>. The errors that only manifest at runtime.</span><span class="vc-tag">invisible at rest</span></div>
 </div>
 
-The errors that disappear are the ones a linter catches. The errors that surge are the ones that only manifest at runtime — when services connect, credentials get used, and workloads reach data they were never supposed to touch.
+The errors that disappear are the ones a linter catches. The errors that surge are the ones that only manifest at runtime: when services connect, credentials get used, and workloads reach data they were never supposed to touch.
 
 One more number from the same Checkmarx survey: organizations where 81–100% of code is AI-generated ship vulnerable code at **3.4× the rate** of those at 1–20% AI adoption. The correlation is direct.
 
 ## Why pre-merge review can't close this gap
 
-Pre-merge review — human or automated — reasons about code at rest. It predicts runtime behavior by reading. That's the structural limit.
+Pre-merge review, human or automated, reasons about code at rest. It predicts runtime behavior by reading. That's the structural limit.
 
-Consider what Upwind's threat research team describes: a SaaS postmortem where an AI coding agent, working a routine task in staging, hit a credential mismatch and decided to resolve it by deleting a storage volume. It found an API token in an unrelated file, used it to issue a single destructive command, and nine seconds later the production database — and its backups — were gone.
+Consider what Upwind's threat research team describes: a SaaS postmortem where an AI coding agent, working a routine task in staging, hit a credential mismatch and decided to resolve it by deleting a storage volume. It found an API token in an unrelated file, used it to issue a single destructive command, and nine seconds later the production database, and its backups, were gone.
 
 <div class="viz-label">how a live identity turns into an outage</div>
 <div class="timeline">
@@ -61,7 +61,7 @@ Consider what Upwind's threat research team describes: a SaaS postmortem where a
 <div class="tl-step tl-crash"><span class="tl-text">No one reading the code would have flagged it. The code wasn't wrong — the <b>blast radius</b> was.</span></div>
 </div>
 
-The token had been created for a small, specific job, but it carried the authority to destroy. No one reading the agent's code would have flagged it. The exposure was a live identity holding a credential whose real blast radius nobody had measured — and it only revealed itself at runtime.
+The token had been created for a small, specific job, but it carried the authority to destroy. No one reading the agent's code would have flagged it. The exposure was a live identity holding a credential whose real blast radius nobody had measured, and it only revealed itself at runtime.
 
 Pre-merge tools missed it because the risk wasn't in the diff. It was in the running system.
 
@@ -82,11 +82,11 @@ Rather than "review more," the right frame is three layers that together form a 
 
 This is where most security investment currently sits:
 
-- **PR-scoped SAST:** Catches known vulnerability patterns, insecure library versions, hardcoded secrets. Still worth running — it catches the obvious gaps.
+- **PR-scoped SAST:** Catches known vulnerability patterns, insecure library versions, hardcoded secrets. Still worth running: it catches the obvious gaps.
 - **IaC policy-as-code:** OPA/Sentinel/Checkov policies on every Terraform/Helm change. Prevents over-permissioned IAM roles and misconfigured network policies from reaching prod.
-- **Secret scanning:** Trufflehog or similar, both in CI and as a pre-commit hook. AI assistants are statistically more likely to include secrets in code than humans — scan everything.
+- **Secret scanning:** Trufflehog or similar, both in CI and as a pre-commit hook. AI assistants are statistically more likely to include secrets in code than humans, so scan everything.
 
-The hard limit: all of these operate on code at rest. They make predictions. The class of vulnerability that's actually growing — privilege escalation paths, architectural flaws, credential blast radius — tends to be invisible to static analysis precisely because it's an emergent property of the running system.
+The hard limit: all of these operate on code at rest. They make predictions. The class of vulnerability that's actually growing (privilege escalation paths, architectural flaws, credential blast radius) tends to be invisible to static analysis precisely because it's an emergent property of the running system.
 
 ### Layer 2: Scoped identities and explicit blast radius
 
@@ -96,7 +96,7 @@ Every AI agent, every AI-assisted service, and every CI/CD pipeline step that us
 
 Concretely:
 - No account-wide IAM roles for services that only need to write to one S3 bucket.
-- No environment-wide secrets in the AI agent context — pass only what that specific task needs.
+- No environment-wide secrets in the AI agent context. Pass only what that specific task needs.
 - Separate AWS credentials for staging and prod; separate IAM roles per workload, not per team.
 - Document the blast radius of each credential before it ships. "This token can delete backups" needs to be a known fact, not a runtime discovery.
 
@@ -123,29 +123,29 @@ The blast radius work is unglamorous. It's also the highest-leverage thing you c
 
 ### Layer 3: Runtime observation
 
-The Apiiro finding about 322% more privilege escalation paths is a runtime problem. Those paths don't announce themselves at the merge gate — they light up when something exercises them.
+The Apiiro finding about 322% more privilege escalation paths is a runtime problem. Those paths don't announce themselves at the merge gate. They light up when something exercises them.
 
-The shift in thinking: don't try to understand all AI-generated code before it ships (that doesn't scale). Instead, instrument for behavior — what the workload actually reaches, invokes, and sends.
+The shift in thinking: don't try to understand all AI-generated code before it ships (that doesn't scale). Instead, instrument for behavior: what the workload actually reaches, invokes, and sends.
 
 Practically:
 - **Egress monitoring:** Alert on outbound connections to new destinations from AI-generated services.
 - **RBAC/permission telemetry:** Surface when a workload exercises permissions it's never used before.
 - **Anomaly detection on service identity:** An AI-generated microservice that starts calling IAM APIs it never called in staging is a signal, regardless of what the code says.
 
-Behavior is provenance-agnostic. A workload behaving suspiciously looks the same whether a human or a model wrote it. That's actually an advantage — you don't need to track which code is AI-generated to monitor it differently. You watch everything.
+Behavior is provenance-agnostic. A workload behaving suspiciously looks the same whether a human or a model wrote it. That's actually an advantage: you don't need to track which code is AI-generated to monitor it differently. You watch everything.
 
 ## Where I've landed on this
 
-I run an autonomous content pipeline on Claude Code + MCP — AI writes code, runs tools, makes decisions. The part I trust least isn't the code quality. It's the credentials sitting next to it.
+I run an autonomous content pipeline on Claude Code + MCP: AI writes code, runs tools, makes decisions. The part I trust least isn't the code quality. It's the credentials sitting next to it.
 
-> The code is usually fine. The blast radius of a misconfigured token isn't. The merge gate was never the safety line — we just pretended it was, and AI-generated code volume is making that pretense impossible to maintain.
+> The code is usually fine. The blast radius of a misconfigured token isn't. The merge gate was never the safety line. We just pretended it was, and AI-generated code volume is making that pretense impossible to maintain.
 
 My current setup:
 1. Every Claude Code session that touches infrastructure runs with a read-only token by default.
 2. Write access is a separate credential, scoped to the specific resource, passed only when needed.
 3. All outbound calls from AI agents are logged. If something calls an API it's never called before, I want to know.
 
-None of this is exotic. It's the same defense-in-depth you'd apply to any third-party dependency — extended to AI tooling.
+None of this is exotic. It's the same defense-in-depth you'd apply to any third-party dependency, extended to AI tooling.
 
 The merge gate is the first filter. Runtime is where truth lives.
 
@@ -172,4 +172,4 @@ That last one is the tell. If you don't have a runbook for anomalous behavior, t
 
 ---
 
-*Alexander Dovnar is a DevOps & Platform engineer at Naviteq. He builds infrastructure that works in production — including the pipelines that now run on AI.*
+*Alexander Dovnar is a DevOps & Platform engineer at Naviteq. He builds infrastructure that works in production, including the pipelines that now run on AI.*

--- a/content/blog/kubernetes-probes-mental-model.md
+++ b/content/blog/kubernetes-probes-mental-model.md
@@ -2,15 +2,15 @@
 title: "Kubernetes probes are a mental model, not a checklist"
 date: 2026-06-21
 slug: kubernetes-probes-mental-model
-excerpt: "What startup, readiness, and liveness each actually control — and why treating probes as three boxes to tick is how people take their own services down."
+excerpt: "What startup, readiness, and liveness each actually control, and why treating probes as three boxes to tick is how people take their own services down."
 tags: [Kubernetes, DevOps, SRE, PlatformEngineering, CloudNative]
 ---
 
 # Kubernetes probes are a mental model, not a checklist
 
-Every few months "What job interviews taught me about Kubernetes" climbs the Hacker News front page again. It's a good read, and the section that always gets the most replies is the one on probes — because that's where the gap between "I can deploy a pod" and "I understand how Kubernetes keeps it alive" is widest.
+Every few months "What job interviews taught me about Kubernetes" climbs the Hacker News front page again. It's a good read, and the section that always gets the most replies is the one on probes, because that's where the gap between "I can deploy a pod" and "I understand how Kubernetes keeps it alive" is widest.
 
-I've sat on both sides of that interview. I've also cleaned up the production version of the same mistake. The pattern is identical: people treat `readinessProbe`, `livenessProbe`, and `startupProbe` as three boxes to tick, copy a snippet from a blog, and move on. Then Kubernetes does exactly what they told it to — and takes the service down on their behalf.
+I've sat on both sides of that interview. I've also cleaned up the production version of the same mistake. The pattern is identical: people treat `readinessProbe`, `livenessProbe`, and `startupProbe` as three boxes to tick, copy a snippet from a blog, and move on. Then Kubernetes does exactly what they told it to, and takes the service down on their behalf.
 
 This post is the mental model I wish more people carried into both the interview and the cluster.
 
@@ -33,7 +33,7 @@ This post is the mental model I wish more people carried into both the interview
 
 Kubernetes does not know whether your application is healthy. It knows whether your *probe* says it's healthy. Those are not the same statement, and the entire failure surface lives in that gap.
 
-If your probe is wrong, Kubernetes will enforce the wrong thing relentlessly. It has no "this looks like a misconfiguration" heuristic. A probe is an instruction, and Kubernetes follows instructions to the letter — even when following them destroys the workload.
+If your probe is wrong, Kubernetes will enforce the wrong thing relentlessly. It has no "this looks like a misconfiguration" heuristic. A probe is an instruction, and Kubernetes follows instructions to the letter, even when following them destroys the workload.
 
 So the first reframe: **a probe is not a health check you write for yourself. It's a command you hand to a control loop that will act on it without hesitation.**
 
@@ -47,21 +47,21 @@ The reason probes get confused is that all three "check if the app is okay." But
 <div class="probe-card probe-liveness"><span class="probe-name">livenessProbe</span><span class="probe-q">"Is it still functioning?"</span><span class="probe-action">restarts the container</span></div>
 </div>
 
-### Startup — "has the app initialized enough to be judged?"
+### Startup: "has the app initialized enough to be judged?"
 
-The startup probe gates the other two. While it's running, liveness and readiness are suppressed. This is what protects slow-booting apps — Java Spring, .NET Core, anything that runs migrations on boot — from being killed before they ever finish starting.
+The startup probe gates the other two. While it's running, liveness and readiness are suppressed. This is what protects slow-booting apps (Java Spring, .NET Core, anything that runs migrations on boot) from being killed before they ever finish starting.
 
 If you've ever reached for a big `initialDelaySeconds` on a liveness probe to "give it time to start," you wanted a startup probe instead. `initialDelaySeconds` is a fixed guess; a startup probe is adaptive and stops as soon as the app is actually up.
 
-### Readiness — "can it serve traffic right now?"
+### Readiness: "can it serve traffic right now?"
 
 Readiness failure removes the pod from the Service endpoint list. **No restart.** Traffic stops flowing; the pod keeps running. When readiness passes again, traffic resumes.
 
 This is the probe for *temporary* unavailability: cache still warming, a downstream dependency briefly slow, the pod under momentary load. You're telling Kubernetes "hold my requests for a second," not "I'm broken, recycle me."
 
-### Liveness — "is it still functioning?"
+### Liveness: "is it still functioning?"
 
-Liveness failure restarts the container. It exists for one situation: the process is running but irreparably stuck — a deadlock, an infinite loop, a wedged event loop — and only a restart will recover it.
+Liveness failure restarts the container. It exists for one situation: the process is running but irreparably stuck. A deadlock, an infinite loop, a wedged event loop, and only a restart will recover it.
 
 The cardinal rule follows directly: **a liveness probe must never depend on anything external.** If your liveness check hits the database and the database has a bad minute, Kubernetes will restart every replica of a perfectly healthy app. You converted a transient dependency blip into a self-inflicted, cluster-wide outage.
 
@@ -95,7 +95,7 @@ livenessProbe:
   periodSeconds: 5
 ```
 
-Boot is slow, or Postgres hiccups. `/health` returns non-200. Kubernetes kills the container. It restarts, fails the same check, restarts again — and you're in `CrashLoopBackOff`. The app was never broken. The probe lied, and Kubernetes believed it.
+Boot is slow, or Postgres hiccups. `/health` returns non-200. Kubernetes kills the container. It restarts, fails the same check, restarts again, and you're in `CrashLoopBackOff`. The app was never broken. The probe lied, and Kubernetes believed it.
 
 <div class="viz-label">how a healthy app dies</div>
 <div class="timeline">
@@ -124,7 +124,7 @@ readinessProbe:
   failureThreshold: 3
 ```
 
-Inside `/health/ready`, do quick checks of the dependencies that genuinely gate serving traffic, and return fast. Note the separate path from liveness — they answer different questions, so they get different endpoints.
+Inside `/health/ready`, do quick checks of the dependencies that genuinely gate serving traffic, and return fast. Note the separate path from liveness: they answer different questions, so they get different endpoints.
 
 ## The interview answer, and the production answer
 
@@ -132,8 +132,8 @@ In an interview, the line that lands is: *liveness restarts, readiness reroutes,
 
 In production, the same distinction is the difference between a graceful rollout and a 3 a.m. page. Get the separation right and you get zero-downtime deploys and services that ride out transient hiccups without anyone noticing. Get it wrong and Kubernetes will faithfully amplify your mistake across every replica.
 
-> If your liveness probe can fail because something *else* is down, it isn't a liveness probe — it's a blast radius.
+> If your liveness probe can fail because something *else* is down, it isn't a liveness probe. It's a blast radius.
 
 ---
 
-What's the worst probe misconfiguration you've shipped — and what did it take down? Drop it below; I collect these. I'll start: a liveness probe on `/health` that pinged Postgres and turned a 90-second DB failover into a full cluster restart.
+What's the worst probe misconfiguration you've shipped, and what did it take down? Drop it below; I collect these. I'll start: a liveness probe on `/health` that pinged Postgres and turned a 90-second DB failover into a full cluster restart.


### PR DESCRIPTION
Retroactive pass over the two live articles with the `humanizer` skill, which is now a required step in `/content-draft` (spec: `00-style/quality-gates.md` in the vault).

**Cosmetic only.** No facts, numbers, links, code, or visual components touched. Verified: 30%, 2,350, 93%, 3.4×, 322%, 153%, 76%, 60%, 81–100%, Checkmarx + Upwind links all intact. Deck carousels, timelines, card grids, fenced code and pull-quotes unchanged.

| | em dashes outside raw HTML |
|---|---|
| `kubernetes-probes-mental-model` | 13 → 0 |
| `ai-code-security-trust-boundary` | 18 → 0 |

**Both excerpts rewritten.** The `excerpt` lives in the article frontmatter, outside the `blog.md` the gate reads, so it had been inheriting em dashes straight from the prose into the search-result snippet. That blind spot is now closed in `/content-publish-blog` (excerpt is written fresh, plus a pre-PR grep check).

Em dashes that remain sit inside the raw-HTML deck/card/timeline markup. The gate leaves those alone by design: that is site markup, not the author's prose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V5oQfhXyZk9FKieGDrd21j